### PR TITLE
Implement `sectionWrap` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ elements and any following content with `<section>` tags
   - [options](#options)
     - [options.sectionDataAttribute](#optionsheadingiddataattribute)
     - [options.maxHeadingLevel](#optionsmaxheadinglevel)
-    - [options.wrap](#optionswrap)
+    - [options.headerWrap](#optionsheaderwrap)
+    - [options.contentWrap](#optionscontentwrap)
 - [License](#license)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ rehype().use(rehypeSectionHeadings, { maxHeadingLevel: 2 }).process(html);
 </section>
 ```
 
-#### options.wrap
+#### options.headerWrap
 
 Type:
 `Partial<Record<"h1" | "h2" | "h3" | "h4" | "h5" | "h6", string | Hast.Element>>`. Default: `{}`.
@@ -197,7 +197,7 @@ const html = `
 `;
 
 rehype()
-  .use(rehypeSectionHeadings, { wrap: { h1: "aside" } })
+  .use(rehypeSectionHeadings, { headerWrap: { h1: "aside" } })
   .process(html);
 ```
 
@@ -234,7 +234,7 @@ const html = `
 
 rehype()
   .use(rehypeSectionHeadings, {
-    wrap: {
+    headerWrap: {
       h1: {
         type: "element",
         tagName: "aside",
@@ -259,6 +259,151 @@ rehype()
 <section>
   <h2>Heading level 2</h2>
   <p>What is the meaning of life?</p>
+</section>
+```
+
+#### options.contentWrap
+
+Type: `string | Hast.Element`. default: `null`.
+
+An optional element to wrap the content of a section in. Useful as a jumping-off point when you need to further customize a section's content. Accepts either a string (i.e. a tag name like `"div"`) or a hast Element.
+
+```js
+import rehype from "rehype";
+import rehypeSectionHeadings from "@maxmmyron/rehype-section-headings";
+
+const html = `
+<h1>Heading level 1</h1>
+<p>Hey, World!</p>
+<p>This is a bit of content.</p>
+<img src="LK-99.png" alt="A supposed room-temperature superconductor." />
+<h2>Heading level 2</h2>
+<p>I want to believe!!!</p>
+`;
+
+rehype().use(rehypeSectionHeadings, { contentWrap: "main" }).process(html);
+```
+
+...results in the following output
+
+```html
+<section>
+  <h1>Heading level 1</h1>
+  <main>
+    <p>Hey, World!</p>
+    <p>This is a bit of content.</p>
+    <img src="LK-99.png" alt="A supposed room-temperature superconductor." />
+  </main>
+</section>
+<section>
+  <h2>Heading level 2</h2>
+  <main>
+    <p>I want to believe!!!</p>
+  </main>
+</section>
+```
+
+We can also provide this as a hast element, to get more granular control over the element's properties:
+
+```js
+import rehype from "rehype";
+import rehypeSectionHeadings from "@maxmmyron/rehype-section-headings";
+
+const html = `
+<h1>Heading level 1</h1>
+<p>Hey, World!</p>
+<p>This is a bit of content.</p>
+<img src="LK-99.png" alt="A supposed room-temperature superconductor." />
+<h2>Heading level 2</h2>
+<p>I want to believe!!!</p>
+`;
+
+rehype()
+  .use(rehypeSectionHeadings, {
+    contentWrap: {
+      type: "element",
+      tagName: "main",
+      properties: { className: ["content"] },
+      children: [],
+    },
+  })
+  .process(html);
+```
+
+...results in the following output
+
+```html
+<section>
+  <h1>Heading level 1</h1>
+  <main class="content">
+    <p>Hey, World!</p>
+    <p>This is a bit of content.</p>
+    <img src="LK-99.png" alt="A supposed room-temperature superconductor." />
+  </main>
+</section>
+<section>
+  <h2>Heading level 2</h2>
+  <main class="content">
+    <p>I want to believe!!!</p>
+  </main>
+</section>
+```
+
+We can even combine this with [`options.headerWrap`](#optionsheaderwrap) to get even more control over the output:
+
+```js
+import rehype from "rehype";
+
+const html = `
+<h1>Heading level 1</h1>
+<p>Hey, World!</p>
+<p>This is a bit of content.</p>
+<img src="LK-99.png" alt="A supposed room-temperature superconductor." />
+<h2>Heading level 2</h2>
+<p>I want to believe!!!</p>
+`;
+
+rehype()
+  .use(rehypeSectionHeadings, {
+    headerWrap: {
+      h1: "header",
+      h2: {
+        type: "element",
+        tagName: "aside",
+        properties: { className: ["aside"] },
+        children: [],
+      },
+    },
+    contentWrap: {
+      type: "element",
+      tagName: "main",
+      properties: { className: ["content"] },
+      children: [],
+    },
+  })
+  .process(html);
+```
+
+...results in the following output
+
+```html
+<section>
+  <header>
+    <h1>Heading level 1</h1>
+  </header>
+  <main class="content">
+    <p>Hey, World!</p>
+    <p>This is a bit of content.</p>
+    <img src="LK-99.png" alt="A supposed room-temperature superconductor." />
+  </main>
+</section>
+<section>
+  <aside class="aside">
+    <h2>Heading level 2</h2>
+  </aside>
+  <main class="content">
+    <p>I want to believe!!!</p>
+  </main>
 </section>
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,6 @@ const rehypeSectionHeadings: Plugin<[RehypeSectionHeadingsOptions?], Root> = (
         return;
       }
 
-
       let nextHeadingIdx = currentHeadingIdx;
       while (++nextHeadingIdx < parent.children.length) {
         const nextNode = parent.children[nextHeadingIdx];
@@ -135,23 +134,30 @@ function wrapWithSection(
   ) {
     const wrapper = headerWrap[headingElement.tagName as Headers];
 
-    if(wrapper !== undefined && wrapper !== null && wrapper !== "") {
+    if (wrapper !== undefined && wrapper !== null && wrapper !== "") {
       tree.splice(currentHeadingIdx, 1, {
         type: "element",
         tagName: typeof wrapper === "string" ? wrapper : wrapper.tagName,
         children: [headingElement],
-        properties: typeof wrapper === "string" || !isElement(wrapper) ? {} : wrapper.properties,
+        properties:
+          typeof wrapper === "string" || !isElement(wrapper)
+            ? {}
+            : wrapper.properties,
       });
     }
   }
 
   // wrap main contents
-  if(contentWrap !== null && contentWrap !== "") {
-    const mainContents = tree.slice(currentHeadingIdx + 1, nextHeadingIdx) as ElementContent[];
+  if (contentWrap !== null && contentWrap !== "") {
+    const mainContents = tree.slice(
+      currentHeadingIdx + 1,
+      nextHeadingIdx
+    ) as ElementContent[];
 
     tree.splice(currentHeadingIdx + 1, mainContents.length, {
       type: "element",
-      tagName: typeof contentWrap === "string" ? contentWrap : contentWrap.tagName,
+      tagName:
+        typeof contentWrap === "string" ? contentWrap : contentWrap.tagName,
       children: mainContents,
       properties: typeof contentWrap === "string" ? {} : contentWrap.properties,
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -889,12 +889,12 @@ describe("with maxHeadingLevel", () => {
   });
 });
 
-describe("with headingWrapElement", () => {
+describe("with headingWrap", () => {
   test("wraps headings based on wrap option", () => {
     // Arrange
     const processorWithOption = rehype()
       .use(rehypeParse, { fragment: true })
-      .use(rehypeSectionHeadings, { wrap: { h1: "div", h2: "aside" } })
+      .use(rehypeSectionHeadings, { headerWrap: { h1: "div", h2: "aside" } })
       .use(rehypeStringify);
 
     // Arrange
@@ -931,7 +931,7 @@ describe("with headingWrapElement", () => {
     // Arrange
     const processorWithOption = rehype()
       .use(rehypeParse, { fragment: true })
-      .use(rehypeSectionHeadings, { wrap: { h1: "div", h2: "aside" } })
+      .use(rehypeSectionHeadings, { headerWrap: { h1: "div", h2: "aside" } })
       .use(rehypeStringify);
 
     // Arrange
@@ -974,7 +974,7 @@ describe("with headingWrapElement", () => {
     // Arrange
     const processorWithOption = rehype()
       .use(rehypeParse, { fragment: true })
-      .use(rehypeSectionHeadings, { wrap: { h1: undefined, h2: "" } })
+      .use(rehypeSectionHeadings, { headerWrap: { h1: undefined, h2: "" } })
       .use(rehypeStringify);
 
     // Arrange
@@ -1012,7 +1012,7 @@ describe("with headingWrapElement", () => {
     const processorWithOption = rehype()
       .use(rehypeParse, { fragment: true })
       .use(rehypeSectionHeadings, {
-        wrap: {
+        headerWrap: {
           h1: {
             type: "element",
             tagName: "div",
@@ -1053,4 +1053,162 @@ describe("with headingWrapElement", () => {
       expect(actual?.value).toStrictEqual(expected);
     });
   });
+});
+
+describe("with contentWrap", () => {
+	test("wraps content based on wrap option", () => {
+    // Arrange
+    const processorWithOption = rehype()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeSectionHeadings, {contentWrap: "main"})
+      .use(rehypeStringify);
+
+    // Arrange
+    // prettier-ignore
+    const original = toHtml(
+			[
+				h1("Heading h1"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+				h2("Heading h2"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+			],
+		);
+
+		// prettier-ignore
+		const expected = toHtml(
+			[
+				section(
+					[h1("Heading h1"),
+					main(p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
+				section(
+					[h2("Heading h2"),
+					main(p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
+			],
+		);
+
+		// Act
+		processorWithOption.process(original, (_, actual) => {
+			// Assert
+			expect(actual?.value).toStrictEqual(expected);
+		});
+	});
+
+	test("wraps content using hast element as wrap option", () => {
+		// Arrange
+		const processorWithOption = rehype()
+			.use(rehypeParse, { fragment: true })
+			.use(rehypeSectionHeadings, {contentWrap: {
+				type: "element",
+				tagName: "main",
+				properties: { className: ["content-wrapper"] },
+				children: [],
+			}})
+			.use(rehypeStringify);
+
+		// Arrange
+		// prettier-ignore
+		const original = toHtml(
+			[
+				h1("Heading h1"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+				h2("Heading h2"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+			],
+		);
+
+		// prettier-ignore
+		const expected = toHtml(
+			[
+				section(
+					[h1("Heading h1"),
+					main({className: ["content-wrapper"]}, p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
+				section(
+					[h2("Heading h2"),
+					main({className: ["content-wrapper"]}, p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
+			],
+		);
+
+		// Act
+		processorWithOption.process(original, (_, actual) => {
+			// Assert
+			expect(actual?.value).toStrictEqual(expected);
+		});
+	});
+
+	test("wraps content with headerWrap option as well", () => {
+		// Arrange
+		const processorWithOption = rehype()
+			.use(rehypeParse, { fragment: true })
+			.use(rehypeSectionHeadings, {contentWrap: "main", headerWrap: {
+				h1: "header",
+				h2: "aside",
+			}})
+			.use(rehypeStringify);
+
+		// Arrange
+		// prettier-ignore
+		const original = toHtml(
+			[
+				h1("Heading h1"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+				h2("Heading h2"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+			],
+		);
+
+		// prettier-ignore
+		const expected = toHtml(
+			[
+				section(
+					[div(h1("Heading h1")),
+					main(p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
+				section(
+					[div(h2("Heading h2")),
+					main(p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
+			],
+		);
+
+		// Act
+		processorWithOption.process(original, (_, actual) => {
+			// Assert
+			expect(actual?.value).toStrictEqual(expected);
+		});
+	});
+
+	test("does not wrap if property value is undefined or empty string", () => {
+		// Arrange
+		const processorWithOption = rehype()
+			.use(rehypeParse, { fragment: true })
+			.use(rehypeSectionHeadings, {contentWrap: ""})
+			.use(rehypeStringify);
+
+		// Arrange
+		// prettier-ignore
+		const original = toHtml(
+			[
+				h1("Heading h1"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+				h2("Heading h2"),
+				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
+			],
+		);
+
+		// prettier-ignore
+		const expected = toHtml(
+			[
+				section(
+					[h1("Heading h1"),
+					p("Lorem ipsum dolor sit amet, consectetur adipiscing elit")]),
+				section(
+					[h2("Heading h2"),
+					p("Lorem ipsum dolor sit amet, consectetur adipiscing elit")]),
+			],
+		);
+
+		// Act
+		processorWithOption.process(original, (_, actual) => {
+			// Assert
+			expect(actual?.value).toStrictEqual(expected);
+		});
+	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1056,11 +1056,11 @@ describe("with headingWrap", () => {
 });
 
 describe("with contentWrap", () => {
-	test("wraps content based on wrap option", () => {
+  test("wraps content based on wrap option", () => {
     // Arrange
     const processorWithOption = rehype()
       .use(rehypeParse, { fragment: true })
-      .use(rehypeSectionHeadings, {contentWrap: "main"})
+      .use(rehypeSectionHeadings, { contentWrap: "main" })
       .use(rehypeStringify);
 
     // Arrange
@@ -1074,8 +1074,8 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// prettier-ignore
-		const expected = toHtml(
+    // prettier-ignore
+    const expected = toHtml(
 			[
 				section(
 					[h1("Heading h1"),
@@ -1086,28 +1086,30 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// Act
-		processorWithOption.process(original, (_, actual) => {
-			// Assert
-			expect(actual?.value).toStrictEqual(expected);
-		});
-	});
+    // Act
+    processorWithOption.process(original, (_, actual) => {
+      // Assert
+      expect(actual?.value).toStrictEqual(expected);
+    });
+  });
 
-	test("wraps content using hast element as wrap option", () => {
-		// Arrange
-		const processorWithOption = rehype()
-			.use(rehypeParse, { fragment: true })
-			.use(rehypeSectionHeadings, {contentWrap: {
-				type: "element",
-				tagName: "main",
-				properties: { className: ["content-wrapper"] },
-				children: [],
-			}})
-			.use(rehypeStringify);
+  test("wraps content using hast element as wrap option", () => {
+    // Arrange
+    const processorWithOption = rehype()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeSectionHeadings, {
+        contentWrap: {
+          type: "element",
+          tagName: "main",
+          properties: { className: ["content-wrapper"] },
+          children: [],
+        },
+      })
+      .use(rehypeStringify);
 
-		// Arrange
-		// prettier-ignore
-		const original = toHtml(
+    // Arrange
+    // prettier-ignore
+    const original = toHtml(
 			[
 				h1("Heading h1"),
 				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
@@ -1116,8 +1118,8 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// prettier-ignore
-		const expected = toHtml(
+    // prettier-ignore
+    const expected = toHtml(
 			[
 				section(
 					[h1("Heading h1"),
@@ -1128,26 +1130,29 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// Act
-		processorWithOption.process(original, (_, actual) => {
-			// Assert
-			expect(actual?.value).toStrictEqual(expected);
-		});
-	});
+    // Act
+    processorWithOption.process(original, (_, actual) => {
+      // Assert
+      expect(actual?.value).toStrictEqual(expected);
+    });
+  });
 
-	test("wraps content with headerWrap option as well", () => {
-		// Arrange
-		const processorWithOption = rehype()
-			.use(rehypeParse, { fragment: true })
-			.use(rehypeSectionHeadings, {contentWrap: "main", headerWrap: {
-				h1: "header",
-				h2: "aside",
-			}})
-			.use(rehypeStringify);
+  test("wraps content with headerWrap option as well", () => {
+    // Arrange
+    const processorWithOption = rehype()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeSectionHeadings, {
+        contentWrap: "main",
+        headerWrap: {
+          h1: "header",
+          h2: "aside",
+        },
+      })
+      .use(rehypeStringify);
 
-		// Arrange
-		// prettier-ignore
-		const original = toHtml(
+    // Arrange
+    // prettier-ignore
+    const original = toHtml(
 			[
 				h1("Heading h1"),
 				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
@@ -1156,8 +1161,8 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// prettier-ignore
-		const expected = toHtml(
+    // prettier-ignore
+    const expected = toHtml(
 			[
 				section(
 					[div(h1("Heading h1")),
@@ -1168,23 +1173,23 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// Act
-		processorWithOption.process(original, (_, actual) => {
-			// Assert
-			expect(actual?.value).toStrictEqual(expected);
-		});
-	});
+    // Act
+    processorWithOption.process(original, (_, actual) => {
+      // Assert
+      expect(actual?.value).toStrictEqual(expected);
+    });
+  });
 
-	test("does not wrap if property value is undefined or empty string", () => {
-		// Arrange
-		const processorWithOption = rehype()
-			.use(rehypeParse, { fragment: true })
-			.use(rehypeSectionHeadings, {contentWrap: ""})
-			.use(rehypeStringify);
+  test("does not wrap if property value is undefined or empty string", () => {
+    // Arrange
+    const processorWithOption = rehype()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeSectionHeadings, { contentWrap: "" })
+      .use(rehypeStringify);
 
-		// Arrange
-		// prettier-ignore
-		const original = toHtml(
+    // Arrange
+    // prettier-ignore
+    const original = toHtml(
 			[
 				h1("Heading h1"),
 				p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"),
@@ -1193,8 +1198,8 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// prettier-ignore
-		const expected = toHtml(
+    // prettier-ignore
+    const expected = toHtml(
 			[
 				section(
 					[h1("Heading h1"),
@@ -1205,10 +1210,10 @@ describe("with contentWrap", () => {
 			],
 		);
 
-		// Act
-		processorWithOption.process(original, (_, actual) => {
-			// Assert
-			expect(actual?.value).toStrictEqual(expected);
-		});
-	});
+    // Act
+    processorWithOption.process(original, (_, actual) => {
+      // Assert
+      expect(actual?.value).toStrictEqual(expected);
+    });
+  });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,6 +21,7 @@ const p = (...args) => h("p", ...args);
 const span = (...args) => h("span", ...args);
 const div = (...args) => h("div", ...args);
 const aside = (...args) => h("aside", ...args);
+const header = (...args) => h("header", ...args);
 
 describe("without options", () => {
   let processor: Processor<Root, Root, Root, string>;
@@ -1165,10 +1166,10 @@ describe("with contentWrap", () => {
     const expected = toHtml(
 			[
 				section(
-					[div(h1("Heading h1")),
+					[header(h1("Heading h1")),
 					main(p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
 				section(
-					[div(h2("Heading h2")),
+					[aside(h2("Heading h2")),
 					main(p("Lorem ipsum dolor sit amet, consectetur adipiscing elit"))]),
 			],
 		);


### PR DESCRIPTION
+ adds `sectionWrap` property, which wraps the sectionized content (besides the header) in a specified element:
```js
import rehype from "rehype";
import rehypeSectionHeadings from "@maxmmyron/rehype-section-headings";

const html = `
<h1>Heading level 1</h1>
<p>Hey, World!</p>
<p>This is a bit of content.</p>
<img src="LK-99.png" alt="A supposed room-temperature superconductor." />
<h2>Heading level 2</h2>
<p>I want to believe!!!</p>
`;

rehype().use(rehypeSectionHeadings, { contentWrap: "main" }).process(html);
```

...results in the following output

```html
<section>
  <h1>Heading level 1</h1>
  <main>
    <p>Hey, World!</p>
    <p>This is a bit of content.</p>
    <img src="LK-99.png" alt="A supposed room-temperature superconductor." />
  </main>
</section>
<section>
  <h2>Heading level 2</h2>
  <main>
    <p>I want to believe!!!</p>
  </main>
</section>
```